### PR TITLE
開始時間が小さい方から表示するようにソートロジックを追加

### DIFF
--- a/app/javascript/components/StudyTimeRecordList.vue
+++ b/app/javascript/components/StudyTimeRecordList.vue
@@ -117,13 +117,17 @@ export default {
       const calendarYear = store.getters.calendarYear
       const calendarMonth = store.getters.calendarMonth
 
-      return store.getters.monthlyStudyTime.filter((studyTimeRecord) => {
-        return studyTimeRecord.started_at.includes(
-          `${calendarYear}-${formatMonth(calendarMonth)}-${formatDay(
-            props.date
-          )}`
-        )
-      })
+      return store.getters.monthlyStudyTime
+        .filter((studyTimeRecord) => {
+          return studyTimeRecord.started_at.includes(
+            `${calendarYear}-${formatMonth(calendarMonth)}-${formatDay(
+              props.date
+            )}`
+          )
+        })
+        .sort((a, b) => {
+          return a.started_at < b.started_at ? -1 : 1
+        })
     })
 
     const formatStartAndEndAt = (timeStamp) => {


### PR DESCRIPTION
## issue
* https://github.com/choco0809/stup/issues/124

## 概要
モーダルウィンドウ上での学習記録を開始時間が小さいほうから表示するように変更した。

### 修正前
<img width="950" alt="20230223-2" src="https://user-images.githubusercontent.com/99729409/220811810-e959d658-8242-42d6-add7-f4c8d6a2e13c.png">

### 修正後
<img width="950" alt="20230223-1" src="https://user-images.githubusercontent.com/99729409/220811819-f4c7b9fd-f278-4e98-a778-514ef639f739.png">

