### PR TITLE
Discord上で学習記録を終了（/end）した時に、24時間以上前回の学習記録から経過している場合に対応した

### DIFF
--- a/app/controllers/api/discord/study_time_records_controller.rb
+++ b/app/controllers/api/discord/study_time_records_controller.rb
@@ -32,7 +32,7 @@ module Api
         @study_time_records = @user.study_time_records
         return render status: :ok, json: { message: NOT_STARTED } if @study_time_records.check_ready_ended?
 
-        @study_time_records.update!(ended_at: params[:ended_at])
+        @study_time_records.last.update!(ended_at: params[:ended_at])
         render status: :ok, json: { message: FINISH_REPORT }
       end
 

--- a/app/controllers/api/discord/study_time_records_controller.rb
+++ b/app/controllers/api/discord/study_time_records_controller.rb
@@ -17,8 +17,7 @@ module Api
 
         @study_time_records = @user.study_time_records
         if @study_time_records.check_ready_started?
-          latest_record = @study_time_records.all.last
-          return render status: :ok, json: { message: reply_incomplete_report(latest_record) }
+          return render status: :ok, json: { message: reply_incomplete_report(@study_time_records.last) }
         end
 
         new_record = @study_time_records.new(started_at: params[:started_at], memo: params[:memo])

--- a/app/controllers/api/discord/study_time_records_controller.rb
+++ b/app/controllers/api/discord/study_time_records_controller.rb
@@ -11,6 +11,7 @@ module Api
       FINISH_REPORT = '学習が終了しました🙆'
       INCOMPLETE_REPORT = '前回の学習記録が終了していません🙅'
       NOT_STARTED = "学習が開始されていません。\n学習の記録を開始してください🙇"
+      OVER_24_HOURS = "前回の学習記録から24時間以上経過しています。\n下記のURLから手動にて終了時間を記入して下さい🙇\n#{STUP_URL}".freeze
 
       def create
         return render status: :ok, json: { message: UNREGISTERED_USER } if @user.nil?
@@ -30,6 +31,10 @@ module Api
 
         @study_time_records = @user.study_time_records
         return render status: :ok, json: { message: NOT_STARTED } if @study_time_records.check_ready_ended?
+
+        if @study_time_records.last.within_24_hours?(params[:ended_at])
+          return render status: :ok, json: { message: OVER_24_HOURS }
+        end
 
         @study_time_records.last.update!(ended_at: params[:ended_at])
         render status: :ok, json: { message: FINISH_REPORT }

--- a/app/javascript/commands/common.js
+++ b/app/javascript/commands/common.js
@@ -1,0 +1,8 @@
+function truncateSeconds(date) {
+  date.setSeconds(0)
+  return date
+}
+
+module.exports = {
+  truncateSeconds
+}

--- a/app/javascript/commands/discord_bot.js
+++ b/app/javascript/commands/discord_bot.js
@@ -1,13 +1,22 @@
 const { Client, GatewayIntentBits } = require('discord.js')
-const client = new Client({ intents: [GatewayIntentBits.Guilds] })
-const startCommand = require('./start_command.js')
-const endCommand = require('./end_command.js')
 
-client.on('ready', () => {
-  console.log(`Logged in as ${client.user.tag}!`)
-})
+const setupCommands = (client) => {
+  const startCommand = require('./start_command.js')
+  const endCommand = require('./end_command.js')
 
-startCommand(client)
-endCommand(client)
+  startCommand(client)
+  endCommand(client)
+}
 
-client.login(process.env.DISCORD_BOT_TOKEN)
+const runBot = () => {
+  const client = new Client({ intents: [GatewayIntentBits.Guilds] })
+
+  client.on('ready', () => {
+    console.log(`Logged in as ${client.user.tag}!`)
+  })
+
+  setupCommands(client)
+  client.login(process.env.DISCORD_BOT_TOKEN)
+}
+
+runBot()

--- a/app/javascript/commands/end_command.js
+++ b/app/javascript/commands/end_command.js
@@ -1,4 +1,5 @@
 const fetch = require('node-fetch')
+const { truncateSeconds } = require('./common')
 
 function endCommand(client) {
   client.on('interactionCreate', async (interaction) => {
@@ -27,15 +28,6 @@ function endCommand(client) {
         })
     }
   })
-}
-
-function truncateSeconds(date) {
-  const year = date.getFullYear()
-  const month = date.getMonth() + 1
-  const day = date.getDate()
-  const hours = date.getHours()
-  const minutes = date.getMinutes()
-  return new Date(`${year}/${month}/${day} ${hours}:${minutes}`)
 }
 
 module.exports = endCommand

--- a/app/javascript/commands/end_command.js
+++ b/app/javascript/commands/end_command.js
@@ -17,12 +17,8 @@ function endCommand(client) {
           'Content-Type': 'application/json'
         }
       })
-        .then((response) => {
-          return response.json()
-        })
-        .then((data) => {
-          return interaction.reply({ content: data.message, ephemeral: true })
-        })
+        .then((response) => response.json())
+        .then((data) => interaction.reply({ content: data.message, ephemeral: true }))
         .catch((error) => {
           console.warn(error)
         })

--- a/app/javascript/commands/end_command.js
+++ b/app/javascript/commands/end_command.js
@@ -18,7 +18,9 @@ function endCommand(client) {
         }
       })
         .then((response) => response.json())
-        .then((data) => interaction.reply({ content: data.message, ephemeral: true }))
+        .then((data) =>
+          interaction.reply({ content: data.message, ephemeral: true })
+        )
         .catch((error) => {
           console.warn(error)
         })

--- a/app/javascript/commands/start_command.js
+++ b/app/javascript/commands/start_command.js
@@ -25,12 +25,8 @@ function startCommand(client) {
           'Content-Type': 'application/json'
         }
       })
-        .then((response) => {
-          return response.json()
-        })
-        .then((data) => {
-          return interaction.reply({ content: data.message, ephemeral: true })
-        })
+        .then((response) => response.json())
+        .then((data) => interaction.reply({ content: data.message, ephemeral: true }))
         .catch((error) => {
           console.warn(error)
         })

--- a/app/javascript/commands/start_command.js
+++ b/app/javascript/commands/start_command.js
@@ -1,17 +1,16 @@
 const fetch = require('node-fetch')
+const { truncateSeconds } = require('./common')
 
 function startCommand(client) {
   client.on('interactionCreate', async (interaction) => {
     if (!interaction.isChatInputCommand()) return
-    let studyRecordsMemo = ''
-    if (interaction.options.getString('メモ') !== null) {
-      studyRecordsMemo = interaction.options.getString('メモ')
-      if (!validateLength(studyRecordsMemo)) {
-        return interaction.reply({
-          content: 'メモは20文字以内で記入してください🙅',
-          ephemeral: true
-        })
-      }
+
+    const studyRecordsMemo = interaction.options.getString('メモ') || ''
+    if (!validateLength(studyRecordsMemo)) {
+      return interaction.reply({
+        content: 'メモは20文字以内で記入してください🙅',
+        ephemeral: true
+      })
     }
 
     if (interaction.commandName === 'start') {
@@ -41,15 +40,6 @@ function startCommand(client) {
 
 function validateLength(value) {
   return value.length <= 20
-}
-
-function truncateSeconds(date) {
-  const year = date.getFullYear()
-  const month = date.getMonth() + 1
-  const day = date.getDate()
-  const hours = date.getHours()
-  const minutes = date.getMinutes()
-  return new Date(`${year}/${month}/${day} ${hours}:${minutes}`)
 }
 
 module.exports = startCommand

--- a/app/javascript/commands/start_command.js
+++ b/app/javascript/commands/start_command.js
@@ -26,7 +26,9 @@ function startCommand(client) {
         }
       })
         .then((response) => response.json())
-        .then((data) => interaction.reply({ content: data.message, ephemeral: true }))
+        .then((data) =>
+          interaction.reply({ content: data.message, ephemeral: true })
+        )
         .catch((error) => {
           console.warn(error)
         })

--- a/app/models/study_time_record.rb
+++ b/app/models/study_time_record.rb
@@ -10,10 +10,10 @@ class StudyTimeRecord < ApplicationRecord
   }
 
   def self.check_ready_started?
-    !all.empty? && all.last.ended_at.nil?
+    !all.empty? && last.ended_at.nil?
   end
 
   def self.check_ready_ended?
-    all.empty? || !all.last.ended_at.nil?
+    all.empty? || !last.ended_at.nil?
   end
 end

--- a/app/models/study_time_record.rb
+++ b/app/models/study_time_record.rb
@@ -18,6 +18,6 @@ class StudyTimeRecord < ApplicationRecord
   end
 
   def within_24_hours?(ended_at)
-    ((Time.zone.parse(ended_at) - started_at) / 1.days).floor != 0
+    (Time.zone.parse(ended_at) - started_at) > 24.hours
   end
 end

--- a/app/models/study_time_record.rb
+++ b/app/models/study_time_record.rb
@@ -16,4 +16,8 @@ class StudyTimeRecord < ApplicationRecord
   def self.check_ready_ended?
     all.empty? || !last.ended_at.nil?
   end
+
+  def within_24_hours?(ended_at)
+    ((Time.zone.parse(ended_at) - started_at) / 1.days).floor != 0
+  end
 end

--- a/spec/controllers/api/discord/study_time_records_controller_spec.rb
+++ b/spec/controllers/api/discord/study_time_records_controller_spec.rb
@@ -3,17 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe Api::Discord::StudyTimeRecordsController, type: :controller do
-  before do
-    stub_const(STUP_URL, 'https://stup.fly.dev/')
-    stub_const(UNREGISTERED_USER, "ユーザーが登録されていません。\n下記のURLからユーザー登録を行った後、再度実行して下さい🙇\n#{STUP_URL}".freeze)
-    stub_const(START_REPORT, '学習の記録を開始しました🙆')
-    stub_const(FINISH_REPORT, '学習が終了しました🙆')
-    stub_const(INCOMPLETE_REPORT, '前回の学習記録が終了していません🙅')
-    stub_const(NOT_STARTED, "学習が開始されていません。\n学習の記録を開始してください🙇")
-    stub_const(OVER_24_HOURS, "前回の学習記録から24時間以上経過しています。\n下記のURLから手動にて終了時間を記入して下さい🙇\n#{STUP_URL}".freeze)
-  end
-
   describe 'create' do
+    STUP_URL = 'https://stup.fly.dev/'
+    UNREGISTERED_USER = "ユーザーが登録されていません。\n下記のURLからユーザー登録を行った後、再度実行して下さい🙇\n#{STUP_URL}".freeze
+    START_REPORT = '学習の記録を開始しました🙆'
+    FINISH_REPORT = '学習が終了しました🙆'
+    INCOMPLETE_REPORT = '前回の学習記録が終了していません🙅'
+    NOT_STARTED = "学習が開始されていません。\n学習の記録を開始してください🙇"
+    OVER_24_HOURS = "前回の学習記録から24時間以上経過しています。\n下記のURLから手動にて終了時間を記入して下さい🙇\n#{STUP_URL}".freeze
+
     let(:user) { FactoryBot.build(:user, uid: '1234567') }
     context 'ユーザーが未登録の場合' do
       it 'ユーザーが未登録の場合、学習記録は作成されないこと' do

--- a/spec/controllers/api/discord/study_time_records_controller_spec.rb
+++ b/spec/controllers/api/discord/study_time_records_controller_spec.rb
@@ -3,14 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe Api::Discord::StudyTimeRecordsController, type: :controller do
-
-  STUP_URL = 'https://stup.fly.dev/'
-  UNREGISTERED_USER = "ユーザーが登録されていません。\n下記のURLからユーザー登録を行った後、再度実行して下さい🙇\n#{STUP_URL}".freeze
-  START_REPORT = '学習の記録を開始しました🙆'
-  FINISH_REPORT = '学習が終了しました🙆'
-  INCOMPLETE_REPORT = '前回の学習記録が終了していません🙅'
-  NOT_STARTED = "学習が開始されていません。\n学習の記録を開始してください🙇"
-  OVER_24_HOURS = "前回の学習記録から24時間以上経過しています。\n下記のURLから手動にて終了時間を記入して下さい🙇\n#{STUP_URL}".freeze
+  before do
+    stub_const(STUP_URL, 'https://stup.fly.dev/')
+    stub_const(UNREGISTERED_USER, "ユーザーが登録されていません。\n下記のURLからユーザー登録を行った後、再度実行して下さい🙇\n#{STUP_URL}".freeze)
+    stub_const(START_REPORT, '学習の記録を開始しました🙆')
+    stub_const(FINISH_REPORT, '学習が終了しました🙆')
+    stub_const(INCOMPLETE_REPORT, '前回の学習記録が終了していません🙅')
+    stub_const(NOT_STARTED, "学習が開始されていません。\n学習の記録を開始してください🙇")
+    stub_const(OVER_24_HOURS, "前回の学習記録から24時間以上経過しています。\n下記のURLから手動にて終了時間を記入して下さい🙇\n#{STUP_URL}".freeze)
+  end
 
   describe 'create' do
     let(:user) { FactoryBot.build(:user, uid: '1234567') }

--- a/spec/controllers/api/discord/study_time_records_controller_spec.rb
+++ b/spec/controllers/api/discord/study_time_records_controller_spec.rb
@@ -3,6 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe Api::Discord::StudyTimeRecordsController, type: :controller do
+
+  STUP_URL = 'https://stup.fly.dev/'
+  UNREGISTERED_USER = "ユーザーが登録されていません。\n下記のURLからユーザー登録を行った後、再度実行して下さい🙇\n#{STUP_URL}".freeze
+  START_REPORT = '学習の記録を開始しました🙆'
+  FINISH_REPORT = '学習が終了しました🙆'
+  INCOMPLETE_REPORT = '前回の学習記録が終了していません🙅'
+  NOT_STARTED = "学習が開始されていません。\n学習の記録を開始してください🙇"
+  OVER_24_HOURS = "前回の学習記録から24時間以上経過しています。\n下記のURLから手動にて終了時間を記入して下さい🙇\n#{STUP_URL}".freeze
+
   describe 'create' do
     let(:user) { FactoryBot.build(:user, uid: '1234567') }
     context 'ユーザーが未登録の場合' do
@@ -12,7 +21,7 @@ RSpec.describe Api::Discord::StudyTimeRecordsController, type: :controller do
           started_at: '2022/12/11 15:00:00'
         }
         expect(response).to have_http_status '200'
-        expect(response.parsed_body['message']).to eq "ユーザーが登録されていません。\n下記のURLからユーザー登録を行った後、再度実行して下さい🙇\nhttps://stup.fly.dev/"
+        expect(response.parsed_body['message']).to eq UNREGISTERED_USER
         expect(StudyTimeRecord.count).to eq 0
       end
     end
@@ -26,7 +35,7 @@ RSpec.describe Api::Discord::StudyTimeRecordsController, type: :controller do
         }
         record = StudyTimeRecord.find_by(user_id: user.id)
         expect(response).to have_http_status '200'
-        expect(response.parsed_body['message']).to eq '学習の記録を開始しました🙆'
+        expect(response.parsed_body['message']).to eq START_REPORT
         expect(StudyTimeRecord.find(record.id).started_at).to eq '2022-12-11 15:00:00.000000000 +0900'
         expect(StudyTimeRecord.count).to eq 1
       end
@@ -45,7 +54,7 @@ RSpec.describe Api::Discord::StudyTimeRecordsController, type: :controller do
         }
 
         expect(response).to have_http_status '200'
-        expect(response.parsed_body['message']).to eq "前回の学習記録が終了していません🙅\n2022/12/11 15:00"
+        expect(response.parsed_body['message']).to eq "#{INCOMPLETE_REPORT}\n2022/12/11 15:00"
         expect(StudyTimeRecord.count).to eq 1
       end
     end
@@ -60,7 +69,7 @@ RSpec.describe Api::Discord::StudyTimeRecordsController, type: :controller do
           ended_at: '2022/12/11 15:00:00'
         }
         expect(response).to have_http_status '200'
-        expect(response.parsed_body['message']).to eq "ユーザーが登録されていません。\n下記のURLからユーザー登録を行った後、再度実行して下さい🙇\nhttps://stup.fly.dev/"
+        expect(response.parsed_body['message']).to eq UNREGISTERED_USER
         expect(StudyTimeRecord.count).to eq 0
       end
     end
@@ -73,7 +82,7 @@ RSpec.describe Api::Discord::StudyTimeRecordsController, type: :controller do
           ended_at: '2022/12/11 15:00:00'
         }
         expect(response).to have_http_status '200'
-        expect(response.parsed_body['message']).to eq "学習が開始されていません。\n学習の記録を開始してください🙇"
+        expect(response.parsed_body['message']).to eq NOT_STARTED
         expect(StudyTimeRecord.count).to eq 0
       end
 
@@ -86,7 +95,7 @@ RSpec.describe Api::Discord::StudyTimeRecordsController, type: :controller do
         record = StudyTimeRecord.find_by(user_id: user.id)
 
         expect(response).to have_http_status '200'
-        expect(response.parsed_body['message']).to eq '学習の記録を開始しました🙆'
+        expect(response.parsed_body['message']).to eq START_REPORT
 
         # 学習記録を終了する
         patch :update, params: {
@@ -95,7 +104,7 @@ RSpec.describe Api::Discord::StudyTimeRecordsController, type: :controller do
         }
 
         expect(response).to have_http_status '200'
-        expect(response.parsed_body['message']).to eq '学習が終了しました🙆'
+        expect(response.parsed_body['message']).to eq FINISH_REPORT
         expect(StudyTimeRecord.find(record.id).ended_at).to eq '2022-12-11 16:00:00.000000000 +0900'
       end
     end

--- a/spec/controllers/api/discord/study_time_records_controller_spec.rb
+++ b/spec/controllers/api/discord/study_time_records_controller_spec.rb
@@ -2,16 +2,16 @@
 
 require 'rails_helper'
 
+STUP_URL = 'https://stup.fly.dev/'
+UNREGISTERED_USER = "ユーザーが登録されていません。\n下記のURLからユーザー登録を行った後、再度実行して下さい🙇\n#{STUP_URL}".freeze
+START_REPORT = '学習の記録を開始しました🙆'
+FINISH_REPORT = '学習が終了しました🙆'
+INCOMPLETE_REPORT = '前回の学習記録が終了していません🙅'
+NOT_STARTED = "学習が開始されていません。\n学習の記録を開始してください🙇"
+OVER_24_HOURS = "前回の学習記録から24時間以上経過しています。\n下記のURLから手動にて終了時間を記入して下さい🙇\n#{STUP_URL}".freeze
+
 RSpec.describe Api::Discord::StudyTimeRecordsController, type: :controller do
   describe 'create' do
-    STUP_URL = 'https://stup.fly.dev/'
-    UNREGISTERED_USER = "ユーザーが登録されていません。\n下記のURLからユーザー登録を行った後、再度実行して下さい🙇\n#{STUP_URL}".freeze
-    START_REPORT = '学習の記録を開始しました🙆'
-    FINISH_REPORT = '学習が終了しました🙆'
-    INCOMPLETE_REPORT = '前回の学習記録が終了していません🙅'
-    NOT_STARTED = "学習が開始されていません。\n学習の記録を開始してください🙇"
-    OVER_24_HOURS = "前回の学習記録から24時間以上経過しています。\n下記のURLから手動にて終了時間を記入して下さい🙇\n#{STUP_URL}".freeze
-
     let(:user) { FactoryBot.build(:user, uid: '1234567') }
     context 'ユーザーが未登録の場合' do
       it 'ユーザーが未登録の場合、学習記録は作成されないこと' do


### PR DESCRIPTION
## issue
* https://github.com/choco0809/stup/issues/71

## 概要
Discord上で終了コマンド(`/end`)を実行した時に最新の学習記録の開始時間と終了時間が24時間以上差がある場合、
学習記録を作成せず、webサービス上から手動で終了時間を記入してもらうよう促すリプライを送るように変更した。

### 修正前
<img width="897" alt="20230429-2" src="https://user-images.githubusercontent.com/99729409/235309008-8dca9543-7547-425e-93ea-4dfc79eb5ecb.png">


### 修正後
<img width="897" alt="20230429-1" src="https://user-images.githubusercontent.com/99729409/235308907-1ef0923a-b087-4bf0-882c-32e073da5ecc.png">

