### PR TITLE
scopeの記載が誤っていたため修正

### DIFF
--- a/app/models/study_time_record.rb
+++ b/app/models/study_time_record.rb
@@ -6,7 +6,7 @@ class StudyTimeRecord < ApplicationRecord
 
   scope :monthly_study_records, lambda { |year, month|
     where("to_char(started_at,'yyyy') = ?", year)
-    where("to_char(started_at,'mm') = ?", month)
+      .where("to_char(started_at,'mm') = ?", month)
   }
 
   def self.check_ready_started?


### PR DESCRIPTION
## issue

## 概要
本来、where(year = yyyy and month = mm)とならないといけないところwhere(month = mm)というSQLになっていたため、
適切なscopeに修正した。