### PR TITLE
カレンダー日付の高さを揃えるように変更

### DIFF
--- a/app/javascript/StudyCalendar.vue
+++ b/app/javascript/StudyCalendar.vue
@@ -38,7 +38,7 @@
               {{ date.date }}
             </div>
             <div class="study-time">
-              <div v-if="isFutureDate(date.date)">　</div>
+              <div v-if="isFutureDate(date.date)">&nbsp;</div>
               <div v-else-if="studyTimesLength(date.dailyStudyTime)">
                 <button @click="openModal(date)">ー</button>
               </div>

--- a/app/javascript/StudyCalendar.vue
+++ b/app/javascript/StudyCalendar.vue
@@ -38,7 +38,7 @@
               {{ date.date }}
             </div>
             <div class="study-time">
-              <div v-if="isFutureDate(date.date)"></div>
+              <div v-if="isFutureDate(date.date)">　</div>
               <div v-else-if="studyTimesLength(date.dailyStudyTime)">
                 <button @click="openModal(date)">ー</button>
               </div>


### PR DESCRIPTION
## issue

## 概要
未来日付の場合、高さがズレていたため高さを統一するようにした。

### 修正前
<img width="624" alt="20230501-2" src="https://user-images.githubusercontent.com/99729409/235378131-d936f89b-1402-4ff3-88b5-ebb9f6b834ff.png">


### 修正後
<img width="624" alt="20230501-1" src="https://user-images.githubusercontent.com/99729409/235378128-a704c1d3-0999-49cf-a853-e4a730eb1600.png">
